### PR TITLE
Add basic ink grouping

### DIFF
--- a/QvPen_InkGroup.cs
+++ b/QvPen_InkGroup.cs
@@ -1,0 +1,39 @@
+using UdonSharp;
+using UnityEngine;
+
+namespace QvPen.UdonScript
+{
+    [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
+    public class QvPen_InkGroup : UdonSharpBehaviour
+    {
+        [System.NonSerialized]
+        public Transform root;
+
+        public void _Init(string name, Transform parent)
+        {
+            var go = new GameObject(name);
+            root = go.transform;
+            SetParentAndResetLocalTransform(root, parent);
+        }
+
+        public void _AddChild(Transform child)
+        {
+            SetParentAndResetLocalTransform(child, root);
+        }
+
+        public void _SetParent(Transform parent)
+        {
+            SetParentAndResetLocalTransform(root, parent);
+        }
+
+        private void SetParentAndResetLocalTransform(Transform child, Transform parent)
+        {
+            if (child == null)
+                return;
+            child.SetParent(parent);
+            child.localPosition = Vector3.zero;
+            child.localRotation = Quaternion.identity;
+            child.localScale = Vector3.one;
+        }
+    }
+}

--- a/QvPen_Pen.cs
+++ b/QvPen_Pen.cs
@@ -867,6 +867,20 @@ namespace QvPen.UdonScript
 
         #endregion
 
+        #region Grouping
+
+        public Transform CreateInkGroup(string name, Transform parent = null)
+        {
+            var group = new GameObject(name).transform;
+            SetParentAndResetLocalTransform(group, parent ? parent : inkPoolRoot);
+            return group;
+        }
+
+        public void SetInkParent(Transform ink, Transform parent)
+            => SetParentAndResetLocalTransform(ink, parent ? parent : inkPoolRoot);
+
+        #endregion
+
         #region SaveLoad
 
         private const string SaveKey = "QvPen_WorldState";

--- a/QvPen_PenManager.cs
+++ b/QvPen_PenManager.cs
@@ -208,6 +208,12 @@ namespace QvPen.UdonScript
         public void CopyWorldStateToClipboard() => pen.CopyStateToClipboard();
 
         public void PasteWorldStateFromClipboard() => pen.PasteStateFromClipboard();
+
+        public Transform CreateInkGroup(string name, Transform parent = null)
+            => pen.CreateInkGroup(name, parent);
+
+        public void SetInkParent(Transform ink, Transform parent)
+            => pen.SetInkParent(ink, parent);
         #endregion
 
         #region Network

--- a/SmewBrush.Tests/Program.cs
+++ b/SmewBrush.Tests/Program.cs
@@ -11,6 +11,9 @@ class Program {
         pen.CopyStateToClipboard();
         pen.RestoreState();
         pen.PasteStateFromClipboard();
+        var group = pen.CreateInkGroup("group");
+        var ink = new UnityEngine.GameObject().transform;
+        pen.SetInkParent(ink, group);
         Console.WriteLine("Tests ran");
         return 0;
     }

--- a/SmewBrush.csproj
+++ b/SmewBrush.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="QvPen_Pen.cs" />
     <Compile Include="QvPen_PenManager.cs" />
+    <Compile Include="QvPen_InkGroup.cs" />
     <Compile Include="stubs/UnityStubs.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add `QvPen_InkGroup` behaviour
- enable creating groups and reparenting drawn ink
- expose grouping helpers on `QvPen_PenManager`
- compile new file in project
- exercise grouping helpers in sample tests

## Testing
- `dotnet test --verbosity minimal` *(fails: All projects are up-to-date for restore)*

------
https://chatgpt.com/codex/tasks/task_e_6855996eca408324b570fb6578f16860